### PR TITLE
Replace $HOME with custom env variable $HOME_DIR 

### DIFF
--- a/openvz-centos/scripts/vagrant.sh
+++ b/openvz-centos/scripts/vagrant.sh
@@ -1,6 +1,6 @@
 date > /etc/vagrant_box_build_time
 
-mkdir -pm 700 $HOME/.ssh
-curl -L https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub -o $HOME/.ssh/authorized_keys
-chmod 0600 $HOME/.ssh/authorized_keys
-chown -R openvz:openvz $HOME/.ssh
+mkdir -pm 700 $HOME_DIR/.ssh
+curl -L https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub -o $HOME_DIR/.ssh/authorized_keys
+chmod 0600 $HOME_DIR/.ssh/authorized_keys
+chown -R openvz:openvz $HOME_DIR/.ssh

--- a/openvz-centos/scripts/virtualbox.sh
+++ b/openvz-centos/scripts/virtualbox.sh
@@ -1,7 +1,6 @@
-VBOX_VERSION=$(cat $HOME/.vbox_version)
+VBOX_VERSION=$(cat $HOME_DIR/.vbox_version)
 cd /tmp
-mount -o loop $HOME/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+mount -o loop $HOME_DIR/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
 sh /mnt/VBoxLinuxAdditions.run
 umount /mnt
-rm -rf $HOME/VBoxGuestAdditions_*.iso
-
+rm -rf $HOME_DIR/VBoxGuestAdditions_*.iso

--- a/openvz-centos/template.json
+++ b/openvz-centos/template.json
@@ -3,6 +3,9 @@
     {
       "type": "shell",
       "execute_command": "echo 'openvz'|sudo -S -E sh '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/openvz"
+      ],
       "override": {
         "virtualbox-iso": {
           "scripts": [

--- a/virtuozzo-7.0/scripts/vagrant.sh
+++ b/virtuozzo-7.0/scripts/vagrant.sh
@@ -1,6 +1,6 @@
 date > /etc/vagrant_box_build_time
 
-mkdir -pm 700 $HOME/.ssh
-curl -L https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub -o $HOME/.ssh/authorized_keys
-chmod 0600 $HOME/.ssh/authorized_keys
-chown -R openvz:openvz $HOME/.ssh
+mkdir -pm 700 $HOME_DIR/.ssh
+curl -L https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub -o $HOME_DIR/.ssh/authorized_keys
+chmod 0600 $HOME_DIR/.ssh/authorized_keys
+chown -R openvz:openvz $HOME_DIR/.ssh

--- a/virtuozzo-7.0/scripts/virtualbox.sh
+++ b/virtuozzo-7.0/scripts/virtualbox.sh
@@ -1,7 +1,7 @@
 VBOX_VERSION=$(cat /home/openvz/.vbox_version)
 
 cd /tmp
-mount -o loop $HOME/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+mount -o loop $HOME_DIR/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
 sh /mnt/VBoxLinuxAdditions.run
 umount /mnt
-rm -rf $HOME/VBoxGuestAdditions_*.iso
+rm -rf $HOME_DIR/VBoxGuestAdditions_*.iso

--- a/virtuozzo-7.0/template.json
+++ b/virtuozzo-7.0/template.json
@@ -3,6 +3,9 @@
     {
       "type": "shell",
       "execute_command": "echo 'openvz'|sudo -S sh '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/openvz"
+      ],
       "override": {
         "virtualbox-iso": {
           "scripts": [


### PR DESCRIPTION
Shell provisioner is running from user root, so `$HOME` will be resolved to `"/root"`
We have to set custom env variable, for example `$HOME_DIR`, and use it instead.