### PR TITLE
Add Vagrantfile template

### DIFF
--- a/openvz-centos/template.json
+++ b/openvz-centos/template.json
@@ -35,7 +35,8 @@
         "vmware": {
           "output": "openvz-centos-6.7-x64-vmware.box"
         }
-      }
+      },
+      "vagrantfile_template": "vagrantfile.tpl"
     }
   ],
   "builders": [

--- a/openvz-centos/vagrantfile.tpl
+++ b/openvz-centos/vagrantfile.tpl
@@ -1,0 +1,3 @@
+Vagrant.configure("2") do |config|
+  config.ssh.username = "openvz"
+end

--- a/virtuozzo-7.0/template.json
+++ b/virtuozzo-7.0/template.json
@@ -35,7 +35,8 @@
         "vmware": {
           "output": "virtuozzo-7-0-x64-vmware.box"
         }
-      }
+      },
+      "vagrantfile_template": "vagrantfile.tpl"
     }
   ],
   "builders": [

--- a/virtuozzo-7.0/vagrantfile.tpl
+++ b/virtuozzo-7.0/vagrantfile.tpl
@@ -1,0 +1,3 @@
+Vagrant.configure("2") do |config|
+  config.ssh.username = "openvz"
+end


### PR DESCRIPTION
Since the default username was changed from "vagrant" to "openvz" (aa1b687) , we should bundle Vagrantfile inside the box.
There `config.ssh.username` should be overridden. Otherwise, `vagrant ssh` is failing.

P.s. Or you can just revert aa1b687 and keep the default username as "vagrant", following the Vagrant conventions. IMO, that would be better.